### PR TITLE
Avoid reading active bindings when printing

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -70,12 +70,14 @@ object_summaries <- function(x) {
     obj_names <- ls(x, all.names = TRUE)
 
   values <- vapply(obj_names, function(name) {
-    obj <- x[[name]]
     if (is.environment(x) && bindingIsActive(name, x)) "active binding"
-    else if (is.function(obj)) "function"
-    else if (is.environment(obj)) "environment"
-    else if (is.atomic(obj)) trim(paste(as.character(obj), collapse = " "))
-    else paste(class(obj), collapse = ", ")
+    else {
+      obj <- x[[name]]
+      if (is.function(obj)) "function"
+      else if (is.environment(obj)) "environment"
+      else if (is.atomic(obj)) trim(paste(as.character(obj), collapse = " "))
+      else paste(class(obj), collapse = ", ")
+    }
   }, FUN.VALUE = character(1))
 
   paste0(

--- a/R/print.R
+++ b/R/print.R
@@ -70,8 +70,9 @@ object_summaries <- function(x) {
     obj_names <- ls(x, all.names = TRUE)
 
   values <- vapply(obj_names, function(name) {
-    if (is.environment(x) && bindingIsActive(name, x)) "active binding"
-    else {
+    if (is.environment(x) && bindingIsActive(name, x)) {
+      "active binding"
+    } else {
       obj <- x[[name]]
       if (is.function(obj)) "function"
       else if (is.environment(obj)) "environment"

--- a/tests/testthat/test-portable.R
+++ b/tests/testthat/test-portable.R
@@ -112,6 +112,18 @@ test_that("Active bindings work", {
       x2 = function(value) {
         if (missing(value)) return(self$x * 2)
         else self$x <- value/2
+      },
+
+      sqrt_of_x = function(value) {
+        if (!missing(value))
+          # In "setter" role
+          stop("Sorry this is a read-only variable.")
+        else {
+          # In "getter" role
+          if (x < 0) stop("The requested value is not available.")
+          else sqrt(x)
+        }
+
       }
     )
   )
@@ -123,6 +135,13 @@ test_that("Active bindings work", {
   A$x2 <- 60
   expect_identical(A$x2, 60)
   expect_identical(A$x, 30)
+
+  A$x <- -2
+  expect_error(A$sqrt_of_x)
+  # print does not throw an error trying to read
+  # the active binding variables
+  muted_print <- function(x) capture.output(print(x))
+  expect_that(muted_print(A), not(throws_error()))
 })
 
 

--- a/tests/testthat/test-portable.R
+++ b/tests/testthat/test-portable.R
@@ -120,8 +120,8 @@ test_that("Active bindings work", {
           stop("Sorry this is a read-only variable.")
         else {
           # In "getter" role
-          if (x < 0) stop("The requested value is not available.")
-          else sqrt(x)
+          if (self$x < 0) stop("The requested value is not available.")
+          else sqrt(self$x)
         }
 
       }


### PR DESCRIPTION
Including the fix and extending a test case