### PR TITLE
Pass dot arguments in print(x, ...) to print method

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -1,7 +1,7 @@
 #' @export
 print.R6 <- function(x, ...) {
   if (is.function(x$print)) {
-    x$print()
+    x$print(...)
 
   } else {
     cat(


### PR DESCRIPTION
This makes it possible to customize the S3 printing method like

print(R6object, digits = 6)

if R6object$print() has a digits argument.