### PR TITLE
show interface for member functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ R6 2.1.1.9xxx
   existing classes that define a public `format` method intended for other
   purposes (#73. Thanks to Kirill Müller)
 
+* Functions are shown with their interface in `print` and `format`, limited
+  to one line (#76. Thanks to Kirill Müller)
+
 R6 2.1.1
 -------------------------------------------------------------------------------
 

--- a/R/print.R
+++ b/R/print.R
@@ -93,7 +93,7 @@ object_summaries <- function(x, exclude = NULL) {
       "active binding"
     } else {
       obj <- .subset2(x, name)
-      if (is.function(obj)) "function"
+      if (is.function(obj)) deparse(args(obj))[[1L]]
       else if (is.environment(obj)) "environment"
       else if (is.null(obj)) "NULL"
       else if (is.atomic(obj)) trim(paste(as.character(obj), collapse = " "))


### PR DESCRIPTION
- for `print` and `format` for both `R6` and `R6ClassGenerator`
- first line only
- no width restriction

```
> cl <- R6Class("cl", public = list(cat = cat))
> cl
<cl> object generator
  Public:
    cat: function (..., file = "", sep = " ", fill = FALSE, labels = NULL, 
    clone: function (deep = FALSE) 
  Parent env: <environment: R_GlobalEnv>
  Locked objects: TRUE
  Locked class: FALSE
  Portable: TRUE
> cl$new()
<cl>
  Public:
    cat: function (..., file = "", sep = " ", fill = FALSE, labels = NULL, 
    clone: function (deep = FALSE) 
```