### PR TITLE
Finalizers, closes #92

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+R6 2.1.3.9000
+
+* Classes can define finalizers explicitly, by defining a
+  public `finalize` method. (#92, #93)
+
 R6 2.1.3
 -------------------------------------------------------------------------------
 

--- a/R/new.R
+++ b/R/new.R
@@ -147,6 +147,16 @@ generator_funs$new <- function(...) {
   } else if (length(list(...)) != 0 ) {
     stop("Called new() with arguments, but there is no initialize method.")
   }
+
+  # Finalize --------------------------------------------------------
+  if (is.function(public_bind_env$finalize)) {
+    reg.finalizer(
+      public_bind_env,
+      function(...) public_bind_env$finalize(),
+      onexit = TRUE
+    )
+  }
+
   public_bind_env
 }
 

--- a/tests/testthat/test-finalizer.R
+++ b/tests/testthat/test-finalizer.R
@@ -1,0 +1,100 @@
+context("finalizer")
+
+
+test_that("Finalizers are called, portable", {
+  parenv <- new.env()
+  parenv$peekaboo <- FALSE
+  AC <- R6Class("AC",
+    public = list(finalize = function() peekaboo <<- TRUE),
+    portable = TRUE,
+    parent_env = parenv
+  )
+  a <- AC$new()
+  rm(a)
+  gc()
+  expect_true(parenv$peekaboo)
+})
+
+
+test_that("Finalizers are called, non-portable", {
+  parenv <- new.env()
+  parenv$peekaboo <- FALSE
+  AC <- R6Class("AC",
+    public = list(finalize = function() peekaboo <<- TRUE),
+    portable = FALSE,
+    parent_env = parenv
+  )
+  a <- AC$new()
+  rm(a)
+  gc()
+  expect_true(parenv$peekaboo)
+})
+
+
+test_that("Finalizers have the right environment, portable", {
+  parenv <- new.env()
+  parenv$pub <- parenv$priv <- FALSE
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() { pub <<- self$mypub; priv <<- private$mypriv },
+      mypub = TRUE
+    ),
+    private = list(
+      mypriv = TRUE
+    ),
+    portable = TRUE,
+    parent_env = parenv
+  )
+  a <- AC$new()
+  rm(a)
+  gc()
+  expect_true(parenv$pub)
+  expect_true(parenv$priv)
+})
+
+
+test_that("Finalizers have the right environment, non-portable #1", {
+  parenv <- new.env()
+  parenv$pub <- parenv$priv <- FALSE
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() { pub <<- self$mypub; priv <<- private$mypriv },
+      mypub = TRUE
+    ),
+    private = list(
+      mypriv = TRUE
+    ),
+    portable = FALSE,
+    parent_env = parenv
+  )
+  a <- AC$new()
+  rm(a)
+  gc()
+  expect_true(parenv$pub)
+  expect_true(parenv$priv)
+})
+
+
+test_that("Finalizers have the right environment, non-portable #2", {
+  parenv <- new.env()
+  parenv$pub <- parenv$priv <- FALSE
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() { pub <<- mypub; priv <<- mypriv },
+      mypub = TRUE
+    ),
+    private = list(
+      mypriv = TRUE
+    ),
+    portable = FALSE,
+    parent_env = parenv
+  )
+  a <- AC$new()
+  rm(a)
+  gc()
+  expect_true(parenv$pub)
+  expect_true(parenv$priv)
+})

--- a/tests/testthat/test-finalizer.R
+++ b/tests/testthat/test-finalizer.R
@@ -98,3 +98,265 @@ test_that("Finalizers have the right environment, non-portable #2", {
   expect_true(parenv$pub)
   expect_true(parenv$priv)
 })
+
+
+test_that("Finalizers are inherited, portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() print("An AC was just deleted")
+    )
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC
+  )
+
+  B <- BC$new()
+  expect_output({ rm(B); gc() }, "An AC was just deleted")
+})
+
+
+test_that("Children can override finalizers, portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted")
+    )
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() cat("A BC was just deleted")
+    )
+  )
+
+  B <- BC$new()
+  ## The anchors make sure that there is no extra output here
+  expect_output({ rm(B); gc() }, "^A BC was just deleted$")
+})
+
+
+test_that("Children can call finalizers in the parent, portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted\n")
+    )
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A BC was just deleted\n")
+      }
+    )
+  )
+
+  B <- BC$new()
+  expect_output(
+    { rm(B); gc() },
+    "An AC was just deleted.*A BC was just deleted"
+  )
+})
+
+
+test_that("Finalizers and two levels of inheritance, portable", {
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted\n")
+    )
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A BC was just deleted\n")
+      }
+    )
+  )
+
+  CC <- R6Class(
+    "CC",
+    inherit = BC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A CC was just deleted\n")
+      }
+    )
+  )
+
+  C <- CC$new()
+  expect_output(
+    { rm(C); gc() },
+    "An AC was just deleted.*A BC was just deleted.*A CC was just deleted"
+  )
+})
+
+
+test_that("Finalizers are inherited, non-portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() print("An AC was just deleted")
+    ),
+    portable = FALSE
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    portable = FALSE
+  )
+
+  B <- BC$new()
+  expect_output({ rm(B); gc() }, "An AC was just deleted")
+})
+
+
+test_that("Children can override finalizers, non-portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted")
+    ),
+    portable = FALSE
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() cat("A BC was just deleted")
+    ),
+    portable = FALSE
+  )
+
+  B <- BC$new()
+  ## The anchors make sure that there is no extra output here
+  expect_output({ rm(B); gc() }, "^A BC was just deleted$")
+})
+
+
+test_that("Children can call finalizers in the parent, non-portable", {
+
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted\n")
+    ),
+    portable = FALSE
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A BC was just deleted\n")
+      }
+    ),
+    portable = FALSE
+  )
+
+  B <- BC$new()
+  expect_output(
+    { rm(B); gc() },
+    "An AC was just deleted.*A BC was just deleted"
+  )
+})
+
+
+test_that("Finalizers and two levels of inheritance, portable", {
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted\n")
+    )
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A BC was just deleted\n")
+      }
+    )
+  )
+
+  CC <- R6Class(
+    "CC",
+    inherit = BC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A CC was just deleted\n")
+      }
+    )
+  )
+
+  C <- CC$new()
+  expect_output(
+    { rm(C); gc() },
+    "An AC was just deleted.*A BC was just deleted.*A CC was just deleted"
+  )
+})
+
+test_that("Finalizers and two levels of inheritance, non-portable", {
+  AC <- R6Class(
+    "AC",
+    public = list(
+      finalize = function() cat("An AC was just deleted\n")
+    ),
+    portable = FALSE
+  )
+
+  BC <- R6Class(
+    "BC",
+    inherit = AC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A BC was just deleted\n")
+      }
+    ),
+    portable = FALSE
+  )
+
+  CC <- R6Class(
+    "CC",
+    inherit = BC,
+    public = list(
+      finalize = function() {
+        super$finalize()
+        cat("A CC was just deleted\n")
+      }
+    ),
+    portable = FALSE
+  )
+
+  C <- CC$new()
+  expect_output(
+    { rm(C); gc() },
+    "An AC was just deleted.*A BC was just deleted.*A CC was just deleted"
+  )
+})

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -594,35 +594,29 @@ pq <- PrettyCountingQueue$new(1, 2, "foobar")
 pq
 ```
 
-
 ### Finalizers
 
-Sometimes it's useful to run a function when the object is garbage collected. For example, you may want to make sure a file or database connection gets closed. To do this, you can call the `reg.finalizer()` function in your `initialize` method, and pass it `self` as the object that will trigger the function when it is garbage collected.
+Sometimes it's useful to run a function when the object is garbage collected. For example, you may want to make sure a file or database connection gets closed. To do this, you can define a `finalize()` method, which will be called with no arguments when the object is garbage collected.
 
 
 ```{r}
 A <- R6Class("A", public = list(
-  initialize = function() {
-    reg.finalizer(self,
-                  function(e) print("Finalizer has been called!"),
-                  onexit = TRUE)
+  finalize = function() {
+    print("Finalizer has been called!")
   }
 ))
 
 
-# Instantiate an object, but don't save a reference to it
-A$new()
+# Instantiate an object:
+obj <- A$new()
 
-# Run something else to get rid of any references to the object, because the
-# last returned value is saved in .Last.value
-1+1
-
-# Force immediate garbage collection (normally this will happen automatically
-# from time to time)
-gc()
+# Remove the single existing reference to it, and force garbage collection
+# (normally garbage collection will happen automatically from time
+# to time)
+rm(obj); gc()
 ```
 
-In the example above, we used `onexit=TRUE`, so that the finalizer will also be called when R exits. This is useful in some cases, like database connections, but it isn't necessary for others, like open files, since they will be closed anyway when the R process exits.
+Finalizers are implemented using the `reg.finalizer()` function, and they set `onexit=TRUE`, so that the finalizer will also be called when R exits. This is useful in some cases, like database connections.
 
 
 ## Summary


### PR DESCRIPTION
Classes can define a public finalize method, and this will be
called automatically when objects are garbage collected.

The destructor is called with no arguments, but of course it can refer to `self` and `private`, and if the class is not portable, then it can also just refer to members.
